### PR TITLE
Retrieve interface index using `GetAdapterIndex` windows method

### DIFF
--- a/src/list_win.rs
+++ b/src/list_win.rs
@@ -5,7 +5,9 @@ use windows::Win32::Foundation::{
     ERROR_ADDRESS_NOT_ASSOCIATED, ERROR_BUFFER_OVERFLOW, ERROR_INVALID_PARAMETER,
     ERROR_NOT_ENOUGH_MEMORY, ERROR_NO_DATA, ERROR_SUCCESS, WIN32_ERROR,
 };
-use windows::Win32::NetworkManagement::IpHelper::{GetAdaptersAddresses, IP_ADAPTER_UNICAST_ADDRESS_LH};
+use windows::Win32::NetworkManagement::IpHelper::{
+    GetAdaptersAddresses, IP_ADAPTER_UNICAST_ADDRESS_LH,
+};
 use windows::Win32::NetworkManagement::IpHelper::{
     GAA_FLAG_SKIP_ANYCAST, GAA_FLAG_SKIP_MULTICAST, IP_ADAPTER_ADDRESSES_LH,
 };
@@ -85,7 +87,7 @@ pub(crate) fn list_interfaces() -> Result<List, Error> {
                 ips.push(IpRecord { ip, prefix_len });
                 unicast_ptr = unicast.Next;
             }
-            
+
             let ipv4_if_index = adapter.Anonymous1.Anonymous.IfIndex;
             let ipv6_if_index = adapter.Ipv6IfIndex;
             let ifindex = if ipv4_if_index != 0 {


### PR DESCRIPTION
Hey,

I was trying to list all my network adapters from windows using your lib and I had some issue while listing them

When using the `list_interfaces()` form the file `list_win.rs` I saw that you were using the `adapter.Ipv6IfIndex` field which in some cases returns 0. 
When reading about this field in the Windows documentation, 0 is a reserved index and should not be used.
It seems that interfaces that have the ipv6 stack disabled will always return 0.

Which means that some elements of the list will always be overwritten since it's inserting at index 0

```rust
//... list_win.rs
let iface = Interface {
                index: ifindex,
                name,
                hw_addr,
                ips,
            };
ifs.insert(ifindex, iface); 
//... list_win.rs
```

My solution in this PR is using the methods `GetAdapterIndex` from the Windows crate that will always return the right index for a given adapter regardless of the ip stack enabled