### PR TITLE
Ensure AsyncWatch `changed()` futures are `Send`

### DIFF
--- a/src/async_adapter.rs
+++ b/src/async_adapter.rs
@@ -70,8 +70,9 @@ pub trait AsyncFdAdapter {
     fn register(fd: AsyncFd) -> std::io::Result<Box<dyn AsyncFdRegistration>>;
 }
 
-pub type AsyncFdReadableFuture<'a> =
-    Pin<Box<dyn Future<Output = std::io::Result<Box<dyn AsyncFdReadyGuard + 'a>>> + 'a>>;
+pub type AsyncFdReadableFuture<'a> = Pin<
+    Box<dyn Future<Output = std::io::Result<Box<dyn AsyncFdReadyGuard + Send + 'a>>> + Send + 'a>,
+>;
 
 /// Registered readiness source for a watch file descriptor.
 pub trait AsyncFdRegistration: Send + Sync {
@@ -102,7 +103,7 @@ impl AsyncFdRegistration for tokio::io::unix::AsyncFd<OwnedFd> {
     fn readable(&self) -> AsyncFdReadableFuture<'_> {
         Box::pin(async move {
             let guard = self.readable().await?;
-            Ok(Box::new(guard) as Box<dyn AsyncFdReadyGuard>)
+            Ok(Box::new(guard) as Box<dyn AsyncFdReadyGuard + Send>)
         })
     }
 }
@@ -157,7 +158,7 @@ impl AsyncFdRegistration for AsyncIoRegistration {
     fn readable(&self) -> AsyncFdReadableFuture<'_> {
         Box::pin(async move {
             self.0.readable().await?;
-            Ok(Box::new(AsyncIoReadyGuard(&self.0)) as Box<dyn AsyncFdReadyGuard>)
+            Ok(Box::new(AsyncIoReadyGuard(&self.0)) as Box<dyn AsyncFdReadyGuard + Send>)
         })
     }
 }

--- a/src/async_adapter.rs
+++ b/src/async_adapter.rs
@@ -70,9 +70,8 @@ pub trait AsyncFdAdapter {
     fn register(fd: AsyncFd) -> std::io::Result<Box<dyn AsyncFdRegistration>>;
 }
 
-pub type AsyncFdReadableFuture<'a> = Pin<
-    Box<dyn Future<Output = std::io::Result<Box<dyn AsyncFdReadyGuard + Send + 'a>>> + Send + 'a>,
->;
+pub type AsyncFdReadableFuture<'a> =
+    Pin<Box<dyn Future<Output = std::io::Result<Box<dyn AsyncFdReadyGuard + 'a>>> + Send + 'a>>;
 
 /// Registered readiness source for a watch file descriptor.
 pub trait AsyncFdRegistration: Send + Sync {
@@ -80,7 +79,7 @@ pub trait AsyncFdRegistration: Send + Sync {
 }
 
 /// Guard returned once the runtime reports the watch file descriptor as readable.
-pub trait AsyncFdReadyGuard {
+pub trait AsyncFdReadyGuard: Send {
     fn fd(&self) -> AsyncFdRef<'_>;
     fn clear_ready(&mut self);
 }
@@ -103,7 +102,7 @@ impl AsyncFdRegistration for tokio::io::unix::AsyncFd<OwnedFd> {
     fn readable(&self) -> AsyncFdReadableFuture<'_> {
         Box::pin(async move {
             let guard = self.readable().await?;
-            Ok(Box::new(guard) as Box<dyn AsyncFdReadyGuard + Send>)
+            Ok(Box::new(guard) as Box<dyn AsyncFdReadyGuard>)
         })
     }
 }
@@ -158,7 +157,7 @@ impl AsyncFdRegistration for AsyncIoRegistration {
     fn readable(&self) -> AsyncFdReadableFuture<'_> {
         Box::pin(async move {
             self.0.readable().await?;
-            Ok(Box::new(AsyncIoReadyGuard(&self.0)) as Box<dyn AsyncFdReadyGuard + Send>)
+            Ok(Box::new(AsyncIoReadyGuard(&self.0)) as Box<dyn AsyncFdReadyGuard>)
         })
     }
 }

--- a/src/watch_win.rs
+++ b/src/watch_win.rs
@@ -22,6 +22,19 @@ use crate::Error;
 use crate::List;
 use crate::Update;
 
+struct NotificationHandle(HANDLE);
+
+// SAFETY: The cancellation is intended to be used from another thread.
+unsafe impl Send for NotificationHandle {}
+
+impl NotificationHandle {
+    fn cancel(&self) {
+        unsafe {
+            let _ = CancelMibChangeNotify2(self.0);
+        }
+    }
+}
+
 struct WatchState {
     cursor: crate::UpdateCursor,
     /// User's callback
@@ -29,7 +42,7 @@ struct WatchState {
 }
 
 pub(crate) struct WatchHandle {
-    hnd: HANDLE,
+    hnd: NotificationHandle,
     _state: Pin<Box<Mutex<WatchState>>>,
 }
 
@@ -39,20 +52,20 @@ struct QueuedWatchState {
 }
 
 type QueuedWatchRegistration = (
-    HANDLE,
+    NotificationHandle,
     SharedAsyncCallbackQueue,
     Pin<Box<Mutex<QueuedWatchState>>>,
 );
 
 pub(crate) struct AsyncWatch {
-    hnd: HANDLE,
+    hnd: NotificationHandle,
     queue: SharedAsyncCallbackQueue,
     cursor: crate::UpdateCursor,
     _state: Pin<Box<Mutex<QueuedWatchState>>>,
 }
 
 pub(crate) struct BlockingWatch {
-    hnd: HANDLE,
+    hnd: NotificationHandle,
     queue: SharedAsyncCallbackQueue,
     cursor: crate::UpdateCursor,
     _state: Pin<Box<Mutex<QueuedWatchState>>>,
@@ -60,9 +73,7 @@ pub(crate) struct BlockingWatch {
 
 impl Drop for AsyncWatch {
     fn drop(&mut self) {
-        unsafe {
-            let _ = CancelMibChangeNotify2(self.hnd);
-        }
+        self.hnd.cancel();
     }
 }
 
@@ -79,9 +90,7 @@ impl AsyncWatch {
 
 impl Drop for BlockingWatch {
     fn drop(&mut self) {
-        unsafe {
-            let _ = CancelMibChangeNotify2(self.hnd);
-        }
+        self.hnd.cancel();
     }
 }
 
@@ -98,9 +107,7 @@ impl BlockingWatch {
 
 impl Drop for WatchHandle {
     fn drop(&mut self) {
-        unsafe {
-            let _ = CancelMibChangeNotify2(self.hnd);
-        }
+        self.hnd.cancel();
     }
 }
 
@@ -122,7 +129,10 @@ pub(crate) fn watch_interfaces_with_callback<F: FnMut(Update) + Send + 'static>(
             // Trigger an initial update
             handle_notif(&mut state.lock().unwrap(), crate::list::list_interfaces()?);
             // Then return the handle
-            Ok(WatchHandle { hnd, _state: state })
+            Ok(WatchHandle {
+                hnd: NotificationHandle(hnd),
+                _state: state,
+            })
         }
         ERROR_INVALID_HANDLE => Err(Error::InvalidHandle),
         ERROR_INVALID_PARAMETER => Err(Error::InvalidParameter),
@@ -174,7 +184,7 @@ fn register_queued_watcher() -> Result<QueuedWatchRegistration, Error> {
         )
     };
     match res {
-        NO_ERROR => Ok((hnd, queue, state)),
+        NO_ERROR => Ok((NotificationHandle(hnd), queue, state)),
         ERROR_INVALID_HANDLE => Err(Error::InvalidHandle),
         ERROR_INVALID_PARAMETER => Err(Error::InvalidParameter),
         ERROR_NOT_ENOUGH_MEMORY => Err(Error::NotEnoughMemory),

--- a/tests/async_api_test.rs
+++ b/tests/async_api_test.rs
@@ -90,6 +90,27 @@ fn test_watch_interfaces_async_tokio_loopback_changes() {
 }
 
 #[test]
+#[cfg(all(
+    any(target_os = "windows", target_os = "linux", target_vendor = "apple"),
+    feature = "tokio"
+))]
+fn test_watch_interfaces_async_tokio_spawned_task() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+    runtime.block_on(async {
+        let mut watch = netwatcher::watch_interfaces_async::<netwatcher::async_adapter::Tokio>()
+            .expect("failed to create async watcher");
+
+        let task = tokio::spawn(async move { watch.changed().await });
+        let initial = task.await.expect("spawned watch task failed");
+
+        assert!(initial.is_initial);
+    });
+}
+
+#[test]
 #[ignore]
 #[cfg(all(
     any(target_os = "windows", target_os = "linux", target_vendor = "apple"),


### PR DESCRIPTION
Right now they are not since the `Send` bound gets erased in the async adapter machinery. This prevents important things like using watchers in spawned futures.

Closes #5 