### PR TITLE
Contain callback panics at Windows and Android FFI boundaries

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,0 +1,151 @@
+use std::{
+    any::Any,
+    panic::{catch_unwind, AssertUnwindSafe},
+};
+
+use crate::Update;
+
+pub(crate) struct Callback {
+    callback: Box<dyn FnMut(Update) + Send + 'static>,
+    failed: bool,
+}
+
+impl Callback {
+    pub(crate) fn new(callback: Box<dyn FnMut(Update) + Send + 'static>) -> Self {
+        Self {
+            callback,
+            failed: false,
+        }
+    }
+
+    /// Deliver the synchronous initial update.
+    ///
+    /// This intentionally does not catch panics: watcher construction is still on the
+    /// caller's stack and owns all resources needed to unwind cleanly.
+    pub(crate) fn call_initial(&mut self, update: Update) {
+        (self.callback)(update);
+    }
+
+    /// Deliver an update originating from a platform notification.
+    ///
+    /// A callback that unwinds may have left its captured state inconsistent, so it is
+    /// permanently quarantined rather than called again.
+    pub(crate) fn call_from_notification(&mut self, update: Update) {
+        if self.failed {
+            return;
+        }
+
+        if let Err(payload) = catch_unwind(AssertUnwindSafe(|| (self.callback)(update))) {
+            self.failed = true;
+            drop_panic_payload(payload);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_failed(&self) -> bool {
+        self.failed
+    }
+}
+
+/// Drop a caught panic payload without allowing its destructor to unwind.
+///
+/// Panic payloads can have arbitrary destructors. If dropping one panics, forget the
+/// replacement payload: attempting to drop that in turn could recurse indefinitely.
+fn drop_panic_payload(payload: Box<dyn Any + Send>) {
+    if let Err(payload) = catch_unwind(AssertUnwindSafe(|| drop(payload))) {
+        std::mem::forget(payload);
+    }
+}
+
+/// Dispatch an update to a set of callbacks.
+#[cfg(any(target_os = "android", test))]
+pub(crate) fn dispatch_callbacks<'a>(
+    callbacks: impl IntoIterator<Item = &'a mut Callback>,
+    update: Update,
+) {
+    let mut callbacks = callbacks.into_iter().peekable();
+    while let Some(callback) = callbacks.next() {
+        if callbacks.peek().is_some() {
+            callback.call_from_notification(update.clone());
+        } else {
+            callback.call_from_notification(update);
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{catch_unwind, panic_any, AssertUnwindSafe};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use super::*;
+    use crate::List;
+
+    #[test]
+    fn initial_callback_panic_propagates() {
+        let mut callback = Callback::new(Box::new(|_| panic!("initial callback failed")));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            callback.call_initial(List::default().initial_update());
+        }));
+
+        assert!(result.is_err());
+        assert!(!callback.has_failed());
+    }
+
+    #[test]
+    fn dispatch_continues_after_callback_panic() {
+        let failed_calls = Arc::new(AtomicUsize::new(0));
+        let failed_calls_for_callback = failed_calls.clone();
+        let healthy_calls = Arc::new(AtomicUsize::new(0));
+        let healthy_calls_for_callback = healthy_calls.clone();
+
+        let mut callbacks = [
+            Callback::new(Box::new(move |_| {
+                failed_calls_for_callback.fetch_add(1, Ordering::Relaxed);
+                panic!("callback failed");
+            })),
+            Callback::new(Box::new(move |_| {
+                healthy_calls_for_callback.fetch_add(1, Ordering::Relaxed);
+            })),
+        ];
+        let update = List::default().initial_update();
+
+        for _ in 0..2 {
+            dispatch_callbacks(callbacks.iter_mut(), update.clone());
+        }
+
+        assert_eq!(failed_calls.load(Ordering::Relaxed), 1);
+        assert!(callbacks[0].has_failed());
+        assert_eq!(healthy_calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn dispatch_continues_when_panic_payload_drop_panics() {
+        struct PanicsOnDrop;
+
+        impl Drop for PanicsOnDrop {
+            fn drop(&mut self) {
+                panic!("panic payload drop failed");
+            }
+        }
+
+        let healthy_calls = Arc::new(AtomicUsize::new(0));
+        let healthy_calls_for_callback = healthy_calls.clone();
+        let mut callbacks = [
+            Callback::new(Box::new(|_| panic_any(PanicsOnDrop))),
+            Callback::new(Box::new(move |_| {
+                healthy_calls_for_callback.fetch_add(1, Ordering::Relaxed);
+            })),
+        ];
+
+        dispatch_callbacks(callbacks.iter_mut(), List::default().initial_update());
+
+        assert!(callbacks[0].has_failed());
+        assert_eq!(healthy_calls.load(Ordering::Relaxed), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,9 @@ use std::{
 
 mod error;
 
+#[cfg(any(windows, target_os = "android", test))]
+mod callback;
+
 #[cfg(any(windows, target_os = "android"))]
 mod async_callback;
 
@@ -431,6 +434,13 @@ pub fn list_interfaces() -> Result<HashMap<IfIndex, Interface>, Error> {
 ///
 /// The callback will fire once immediately with an initial interface list, and a diff as if
 /// there were originally no interfaces present.
+///
+/// The initial callback is invoked synchronously before this function returns. If it panics,
+/// watcher construction unwinds and no watcher remains registered. Later callbacks execute from
+/// platform notification context. With the default unwinding panic strategy, a later callback
+/// panic is contained and permanently disables that callback watcher without affecting other
+/// watchers. The panic hook still runs, and the returned handle remains safe to drop. With
+/// `panic = "abort"`, any panic still aborts the process.
 ///
 /// This function will return an error if there is a problem configuring the watcher, or if there
 /// is an error retrieving the initial interface list.

--- a/src/watch_android.rs
+++ b/src/watch_android.rs
@@ -3,6 +3,7 @@ use jni::objects::{Global, JClass, JObject, JString};
 use jni::{jni_sig, jni_str, Env, EnvUnowned, NativeMethod};
 use std::collections::HashMap;
 use std::fs;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -10,6 +11,7 @@ use crate::async_callback::{
     next_async_list, push_async_list, shared_async_callback_queue, wait_next_list,
     SharedAsyncCallbackQueue,
 };
+use crate::callback::{dispatch_callbacks, Callback};
 
 const NETWATCHER_DEX_BYTES: &[u8] = include_bytes!(env!("NETWATCHER_DEX_PATH"));
 
@@ -18,7 +20,7 @@ static STATE: OnceLock<Arc<Mutex<State>>> = OnceLock::new();
 type WatcherId = usize;
 
 struct State {
-    callback_watchers: HashMap<WatcherId, Box<dyn FnMut(Update) + Send + 'static>>,
+    callback_watchers: HashMap<WatcherId, Callback>,
     queued_watchers: HashMap<WatcherId, SharedAsyncCallbackQueue>,
     current_interfaces: List,
     next_watcher_id: WatcherId,
@@ -111,12 +113,13 @@ pub(crate) fn watch_interfaces_blocking() -> Result<BlockingWatch, Error> {
 }
 
 fn register_callback_watcher(
-    mut callback: Box<dyn FnMut(Update) + Send + 'static>,
+    callback: Box<dyn FnMut(Update) + Send + 'static>,
 ) -> Result<WatcherId, Error> {
     let state_ref = STATE.get_or_init(init_state).clone();
+    let mut callback = Callback::new(callback);
 
     let current_list = list::list_interfaces()?;
-    callback(current_list.initial_update());
+    callback.call_initial(current_list.initial_update());
 
     let mut state = state_ref.lock().unwrap();
     let id = state.next_watcher_id;
@@ -292,6 +295,10 @@ pub extern "system" fn Java_net_octet_1stream_netwatcher_NetwatcherSupportAndroi
     _env: EnvUnowned<'_>,
     _class: JClass<'_>,
 ) {
+    let _ = catch_unwind(AssertUnwindSafe(interfaces_did_change));
+}
+
+fn interfaces_did_change() {
     let Some(state_ref) = STATE.get() else {
         return;
     };
@@ -308,15 +315,7 @@ pub extern "system" fn Java_net_octet_1stream_netwatcher_NetwatcherSupportAndroi
     state.current_interfaces = new_list;
 
     if let Some(update) = update {
-        let mut callbacks = state.callback_watchers.values_mut().peekable();
-        while let Some(callback) = callbacks.next() {
-            if callbacks.peek().is_some() {
-                callback(update.clone());
-            } else {
-                callback(update);
-                break;
-            }
-        }
+        dispatch_callbacks(state.callback_watchers.values_mut(), update);
     }
     for queue in state.queued_watchers.values() {
         push_async_list(queue, state.current_interfaces.clone());

--- a/src/watch_win.rs
+++ b/src/watch_win.rs
@@ -1,4 +1,5 @@
 use std::ffi::c_void;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::pin::Pin;
 use std::sync::Mutex;
 
@@ -18,6 +19,7 @@ use crate::async_callback::{
     next_async_list, push_async_list, shared_async_callback_queue, wait_next_list,
     SharedAsyncCallbackQueue,
 };
+use crate::callback::Callback;
 use crate::Error;
 use crate::List;
 use crate::Update;
@@ -43,8 +45,8 @@ impl Drop for NotificationHandle {
 
 struct WatchState {
     cursor: crate::UpdateCursor,
-    /// User's callback
-    cb: Box<dyn FnMut(Update) + Send + 'static>,
+    callback: Callback,
+    initialising: bool,
 }
 
 pub(crate) struct WatchHandle {
@@ -104,7 +106,8 @@ pub(crate) fn watch_interfaces_with_callback<F: FnMut(Update) + Send + 'static>(
 ) -> Result<WatchHandle, Error> {
     let state = Box::pin(Mutex::new(WatchState {
         cursor: crate::UpdateCursor::default(),
-        cb: Box::new(callback),
+        callback: Callback::new(Box::new(callback)),
+        initialising: true,
     }));
     let state_ctx = &*state.as_ref() as *const _ as *const c_void;
 
@@ -120,7 +123,10 @@ pub(crate) fn watch_interfaces_with_callback<F: FnMut(Update) + Send + 'static>(
         _ => return Err(Error::UnexpectedWindowsResult(res.0)),
     };
 
-    handle_notif(&mut state.lock().unwrap(), crate::list::list_interfaces()?);
+    let mut state_guard = state.lock().unwrap();
+    let initial_list = crate::list::list_interfaces()?;
+    handle_initial_notif(&mut state_guard, initial_list);
+    drop(state_guard);
 
     Ok(WatchHandle {
         _hnd: hnd,
@@ -184,8 +190,8 @@ unsafe extern "system" fn notif(
     _row: *const MIB_UNICASTIPADDRESS_ROW,
     _notification_type: MIB_NOTIFICATION_TYPE,
 ) {
-    let state_ptr = ctx as *const Mutex<WatchState>;
-    unsafe {
+    let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
+        let state_ptr = ctx as *const Mutex<WatchState>;
         let state_guard = &mut *state_ptr
             .as_ref()
             .expect("callback ctx should never be null")
@@ -195,7 +201,7 @@ unsafe extern "system" fn notif(
             return;
         };
         handle_notif(state_guard, new_list);
-    }
+    }));
 }
 
 unsafe extern "system" fn queued_notif(
@@ -203,8 +209,8 @@ unsafe extern "system" fn queued_notif(
     _row: *const MIB_UNICASTIPADDRESS_ROW,
     _notification_type: MIB_NOTIFICATION_TYPE,
 ) {
-    let state_ptr = ctx as *const Mutex<QueuedWatchState>;
-    unsafe {
+    let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
+        let state_ptr = ctx as *const Mutex<QueuedWatchState>;
         let state_guard = &mut *state_ptr
             .as_ref()
             .expect("callback ctx should never be null")
@@ -214,14 +220,26 @@ unsafe extern "system" fn queued_notif(
             return;
         };
         handle_queued_notif(state_guard, new_list);
-    }
+    }));
+}
+
+fn handle_initial_notif(state: &mut WatchState, new_list: List) {
+    let update = state
+        .cursor
+        .advance(new_list)
+        .expect("initial update should always advance the cursor");
+    state.callback.call_initial(update);
+    state.initialising = false;
 }
 
 fn handle_notif(state: &mut WatchState, new_list: List) {
+    if state.initialising {
+        return;
+    }
     let Some(update) = state.cursor.advance(new_list) else {
         return;
     };
-    (state.cb)(update);
+    state.callback.call_from_notification(update);
 }
 
 fn handle_queued_notif(state: &mut QueuedWatchState, new_list: List) {
@@ -230,4 +248,59 @@ fn handle_queued_notif(state: &mut QueuedWatchState, new_list: List) {
     }
     state.current_list = new_list.clone();
     push_async_list(&state.queue, new_list);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use super::*;
+    use crate::Interface;
+
+    fn list(name: &str) -> List {
+        List(HashMap::from([(
+            1,
+            Interface {
+                index: 1,
+                name: name.to_owned(),
+                hw_addr: String::new(),
+                ips: Vec::new(),
+            },
+        )]))
+    }
+
+    #[test]
+    fn notifications_are_ignored_while_initialising_and_panics_quarantine_the_callback() {
+        let failed_calls = Arc::new(AtomicUsize::new(0));
+        let failed_calls_for_callback = failed_calls.clone();
+        let state = Mutex::new(WatchState {
+            cursor: crate::UpdateCursor::default(),
+            callback: Callback::new(Box::new(move |update| {
+                failed_calls_for_callback.fetch_add(1, Ordering::Relaxed);
+                if !update.is_initial {
+                    panic!("notification callback failed");
+                }
+            })),
+            initialising: true,
+        });
+
+        handle_notif(&mut state.lock().unwrap(), list("before initialisation"));
+        assert_eq!(failed_calls.load(Ordering::Relaxed), 0);
+
+        handle_initial_notif(&mut state.lock().unwrap(), list("initial"));
+        handle_notif(&mut state.lock().unwrap(), list("changed"));
+
+        {
+            let state = state.lock().expect("watch state should not be poisoned");
+            assert!(!state.initialising);
+            assert!(state.callback.has_failed());
+        }
+
+        handle_notif(&mut state.lock().unwrap(), list("changed again"));
+        assert_eq!(failed_calls.load(Ordering::Relaxed), 2);
+    }
 }


### PR DESCRIPTION
## Summary

- contain notification callback panics before they can unwind across Windows or Android FFI boundaries
- quarantine a watcher after its callback panics while leaving other watchers usable
- propagate synchronous initial callback panics, with Windows registration guarded against concurrent notifications during initialisation
- safely dispose of arbitrary panic payloads, including payloads whose destructors panic
- document the callback panic policy and add focused dispatch and Windows state-transition tests

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Closes #12