### PR TITLE
Watch Windows interface lifecycle changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Install DevCon for Windows integration tests
+      if: runner.os == 'Windows'
+      run: choco install devcon.portable --yes --no-progress
+
     - name: Run Rust CI
       shell: bash
       run: sh .github/scripts/rust-ci.sh

--- a/src/watch_win.rs
+++ b/src/watch_win.rs
@@ -7,13 +7,16 @@ use windows::Win32::Foundation::ERROR_INVALID_HANDLE;
 use windows::Win32::Foundation::ERROR_INVALID_PARAMETER;
 use windows::Win32::Foundation::ERROR_NOT_ENOUGH_MEMORY;
 use windows::Win32::Foundation::NO_ERROR;
+use windows::Win32::Foundation::WIN32_ERROR;
 use windows::Win32::NetworkManagement::IpHelper::CancelMibChangeNotify2;
+use windows::Win32::NetworkManagement::IpHelper::MIB_IPINTERFACE_ROW;
 use windows::Win32::NetworkManagement::IpHelper::MIB_NOTIFICATION_TYPE;
 use windows::Win32::NetworkManagement::IpHelper::MIB_UNICASTIPADDRESS_ROW;
-use windows::Win32::{
-    Foundation::HANDLE, NetworkManagement::IpHelper::NotifyUnicastIpAddressChange,
-    Networking::WinSock::AF_UNSPEC,
+use windows::Win32::NetworkManagement::IpHelper::{
+    NotifyIpInterfaceChange, NotifyUnicastIpAddressChange, PIPINTERFACE_CHANGE_CALLBACK,
+    PUNICAST_IPADDRESS_CHANGE_CALLBACK,
 };
+use windows::Win32::{Foundation::HANDLE, Networking::WinSock::AF_UNSPEC};
 
 use crate::async_callback::{
     next_async_list, push_async_list, shared_async_callback_queue, wait_next_list,
@@ -25,6 +28,11 @@ use crate::List;
 use crate::Update;
 
 struct NotificationHandle(HANDLE);
+
+struct NotificationHandles {
+    _unicast: NotificationHandle,
+    _interface: NotificationHandle,
+}
 
 // SAFETY: The cancellation is intended to be used from another thread.
 unsafe impl Send for NotificationHandle {}
@@ -50,7 +58,7 @@ struct WatchState {
 }
 
 pub(crate) struct WatchHandle {
-    _hnd: NotificationHandle,
+    _hnds: NotificationHandles,
     _state: Pin<Box<Mutex<WatchState>>>,
 }
 
@@ -61,20 +69,20 @@ struct QueuedWatchState {
 }
 
 type QueuedWatchRegistration = (
-    NotificationHandle,
+    NotificationHandles,
     SharedAsyncCallbackQueue,
     Pin<Box<Mutex<QueuedWatchState>>>,
 );
 
 pub(crate) struct AsyncWatch {
-    _hnd: NotificationHandle,
+    _hnds: NotificationHandles,
     queue: SharedAsyncCallbackQueue,
     cursor: crate::UpdateCursor,
     _state: Pin<Box<Mutex<QueuedWatchState>>>,
 }
 
 pub(crate) struct BlockingWatch {
-    _hnd: NotificationHandle,
+    _hnds: NotificationHandles,
     queue: SharedAsyncCallbackQueue,
     cursor: crate::UpdateCursor,
     _state: Pin<Box<Mutex<QueuedWatchState>>>,
@@ -111,18 +119,7 @@ pub(crate) fn watch_interfaces_with_callback<F: FnMut(Update) + Send + 'static>(
         initialising: true,
     }));
     let state_ctx = &*state.as_ref() as *const _ as *const c_void;
-
-    let mut hnd = HANDLE::default();
-    let res = unsafe {
-        NotifyUnicastIpAddressChange(AF_UNSPEC, Some(notif), Some(state_ctx), false, &mut hnd)
-    };
-    let hnd = match res {
-        NO_ERROR => NotificationHandle(hnd),
-        ERROR_INVALID_HANDLE => return Err(Error::InvalidHandle),
-        ERROR_INVALID_PARAMETER => return Err(Error::InvalidParameter),
-        ERROR_NOT_ENOUGH_MEMORY => return Err(Error::NotEnoughMemory),
-        _ => return Err(Error::UnexpectedWindowsResult(res.0)),
-    };
+    let hnds = register_notifications(state_ctx, Some(unicast_notif), Some(interface_notif))?;
 
     let mut state_guard = state.lock().unwrap();
     let initial_list = crate::list::list_interfaces()?;
@@ -130,7 +127,7 @@ pub(crate) fn watch_interfaces_with_callback<F: FnMut(Update) + Send + 'static>(
     drop(state_guard);
 
     Ok(WatchHandle {
-        _hnd: hnd,
+        _hnds: hnds,
         _state: state,
     })
 }
@@ -138,9 +135,9 @@ pub(crate) fn watch_interfaces_with_callback<F: FnMut(Update) + Send + 'static>(
 #[allow(clippy::extra_unused_type_parameters)]
 pub(crate) fn watch_interfaces_async<A: crate::async_adapter::AsyncFdAdapter>(
 ) -> Result<AsyncWatch, Error> {
-    let (hnd, queue, state) = register_queued_watcher()?;
+    let (hnds, queue, state) = register_queued_watcher()?;
     Ok(AsyncWatch {
-        _hnd: hnd,
+        _hnds: hnds,
         queue,
         cursor: crate::UpdateCursor::default(),
         _state: state,
@@ -148,9 +145,9 @@ pub(crate) fn watch_interfaces_async<A: crate::async_adapter::AsyncFdAdapter>(
 }
 
 pub(crate) fn watch_interfaces_blocking() -> Result<BlockingWatch, Error> {
-    let (hnd, queue, state) = register_queued_watcher()?;
+    let (hnds, queue, state) = register_queued_watcher()?;
     Ok(BlockingWatch {
-        _hnd: hnd,
+        _hnds: hnds,
         queue,
         cursor: crate::UpdateCursor::default(),
         _state: state,
@@ -165,38 +162,82 @@ fn register_queued_watcher() -> Result<QueuedWatchRegistration, Error> {
         initialising: true,
     }));
     let state_ctx = &*state.as_ref() as *const _ as *const c_void;
-
-    let mut hnd = HANDLE::default();
-    let res = unsafe {
-        NotifyUnicastIpAddressChange(
-            AF_UNSPEC,
-            Some(queued_notif),
-            Some(state_ctx),
-            false,
-            &mut hnd,
-        )
-    };
-    let hnd = match res {
-        NO_ERROR => NotificationHandle(hnd),
-        ERROR_INVALID_HANDLE => return Err(Error::InvalidHandle),
-        ERROR_INVALID_PARAMETER => return Err(Error::InvalidParameter),
-        ERROR_NOT_ENOUGH_MEMORY => return Err(Error::NotEnoughMemory),
-        _ => return Err(Error::UnexpectedWindowsResult(res.0)),
-    };
+    let hnds = register_notifications(
+        state_ctx,
+        Some(queued_unicast_notif),
+        Some(queued_interface_notif),
+    )?;
 
     let mut state_guard = state.lock().unwrap();
     let initial_list = crate::list::list_interfaces()?;
     handle_initial_queued_notif(&mut state_guard, initial_list);
     drop(state_guard);
 
-    Ok((hnd, queue, state))
+    Ok((hnds, queue, state))
 }
 
-unsafe extern "system" fn notif(
+fn register_notifications(
+    state_ctx: *const c_void,
+    unicast_callback: PUNICAST_IPADDRESS_CHANGE_CALLBACK,
+    interface_callback: PIPINTERFACE_CHANGE_CALLBACK,
+) -> Result<NotificationHandles, Error> {
+    let mut unicast_hnd = HANDLE::default();
+    let res = unsafe {
+        NotifyUnicastIpAddressChange(
+            AF_UNSPEC,
+            unicast_callback,
+            Some(state_ctx),
+            false,
+            &mut unicast_hnd,
+        )
+    };
+    let unicast = registration_result(res, unicast_hnd)?;
+
+    let mut interface_hnd = HANDLE::default();
+    let res = unsafe {
+        NotifyIpInterfaceChange(
+            AF_UNSPEC,
+            interface_callback,
+            Some(state_ctx),
+            false,
+            &mut interface_hnd,
+        )
+    };
+    let interface = registration_result(res, interface_hnd)?;
+
+    Ok(NotificationHandles {
+        _unicast: unicast,
+        _interface: interface,
+    })
+}
+
+fn registration_result(result: WIN32_ERROR, handle: HANDLE) -> Result<NotificationHandle, Error> {
+    match result {
+        NO_ERROR => Ok(NotificationHandle(handle)),
+        ERROR_INVALID_HANDLE => Err(Error::InvalidHandle),
+        ERROR_INVALID_PARAMETER => Err(Error::InvalidParameter),
+        ERROR_NOT_ENOUGH_MEMORY => Err(Error::NotEnoughMemory),
+        _ => Err(Error::UnexpectedWindowsResult(result.0)),
+    }
+}
+
+unsafe extern "system" fn unicast_notif(
     ctx: *const c_void,
     _row: *const MIB_UNICASTIPADDRESS_ROW,
     _notification_type: MIB_NOTIFICATION_TYPE,
 ) {
+    dispatch_notif(ctx);
+}
+
+unsafe extern "system" fn interface_notif(
+    ctx: *const c_void,
+    _row: *const MIB_IPINTERFACE_ROW,
+    _notification_type: MIB_NOTIFICATION_TYPE,
+) {
+    dispatch_notif(ctx);
+}
+
+fn dispatch_notif(ctx: *const c_void) {
     let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
         let state_ptr = ctx as *const Mutex<WatchState>;
         let state_guard = &mut *state_ptr
@@ -211,11 +252,23 @@ unsafe extern "system" fn notif(
     }));
 }
 
-unsafe extern "system" fn queued_notif(
+unsafe extern "system" fn queued_unicast_notif(
     ctx: *const c_void,
     _row: *const MIB_UNICASTIPADDRESS_ROW,
     _notification_type: MIB_NOTIFICATION_TYPE,
 ) {
+    dispatch_queued_notif(ctx);
+}
+
+unsafe extern "system" fn queued_interface_notif(
+    ctx: *const c_void,
+    _row: *const MIB_IPINTERFACE_ROW,
+    _notification_type: MIB_NOTIFICATION_TYPE,
+) {
+    dispatch_queued_notif(ctx);
+}
+
+fn dispatch_queued_notif(ctx: *const c_void) {
     let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
         let state_ptr = ctx as *const Mutex<QueuedWatchState>;
         let state_guard = &mut *state_ptr

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -13,6 +13,10 @@ use std::time::Duration;
 #[cfg(any(windows, all(unix, not(target_os = "android"))))]
 mod helpers;
 
+#[cfg(windows)]
+#[path = "helpers/windows_interface.rs"]
+mod windows_interface;
+
 #[cfg(any(windows, all(unix, not(target_os = "android"))))]
 fn setup_callback_handler() -> (
     impl Fn(usize) + 'static,
@@ -74,6 +78,24 @@ fn assert_is_initial(updates: &Arc<Mutex<Vec<Update>>>, update_index: usize, exp
     assert_eq!(updates_guard[update_index].is_initial, expected);
 }
 
+#[cfg(windows)]
+fn wait_for_matching_update(
+    receiver: &std::sync::mpsc::Receiver<Update>,
+    description: &str,
+    matches: impl Fn(&Update) -> bool,
+) -> Update {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let update = receiver
+            .recv_timeout(remaining)
+            .unwrap_or_else(|_| panic!("timeout waiting for {description}"));
+        if matches(&update) {
+            return update;
+        }
+    }
+}
+
 #[test]
 fn test_list_interfaces_has_loopback() {
     let interfaces = list_interfaces().expect("failed to list network interfaces");
@@ -88,6 +110,126 @@ fn test_list_interfaces_has_loopback() {
         .any(|interface| interface.ips.contains(&expected_loopback));
 
     assert!(loopback_found, "address 127.0.0.1/8 not found");
+}
+
+#[test]
+#[ignore] // installs a temporary network adapter and requires administrator context
+#[cfg(windows)]
+#[serial(loopback)]
+fn test_watch_interfaces_interface_added_and_removed() {
+    use windows_interface::TestInterface;
+
+    let test_interface = TestInterface::install_disabled();
+    let interface_name = test_interface.name().to_owned();
+    let mut blocking_watch =
+        watch_interfaces_blocking().expect("failed to create blocking watcher");
+    let blocking_initial = blocking_watch.changed();
+    assert!(blocking_initial.is_initial);
+    assert!(
+        blocking_initial
+            .interfaces
+            .values()
+            .all(|interface| interface.name != interface_name),
+        "disabled test interface unexpectedly appeared in blocking initial snapshot"
+    );
+    let blocking_interface_name = interface_name.clone();
+    let (blocking_sender, blocking_receiver) = std::sync::mpsc::channel();
+    let blocking_thread = std::thread::spawn(move || {
+        let added = loop {
+            let update = blocking_watch.changed();
+            if update
+                .diff
+                .added
+                .values()
+                .any(|interface| interface.name == blocking_interface_name)
+            {
+                break update;
+            }
+        };
+        let interface_index = added
+            .diff
+            .added
+            .values()
+            .find(|interface| interface.name == blocking_interface_name)
+            .expect("matching blocking added interface should exist")
+            .index;
+        if blocking_sender.send(added).is_err() {
+            return;
+        }
+
+        let removed = loop {
+            let update = blocking_watch.changed();
+            if update.diff.removed.contains_key(&interface_index) {
+                break update;
+            }
+        };
+        let _ = blocking_sender.send(removed);
+    });
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let handle = watch_interfaces_with_callback(move |update| {
+        let _ = sender.send(update);
+    })
+    .expect("failed to create callback watcher");
+
+    let initial = receiver
+        .recv_timeout(Duration::from_secs(10))
+        .expect("timeout waiting for initial update");
+    assert!(initial.is_initial);
+    assert!(
+        initial
+            .interfaces
+            .values()
+            .all(|interface| interface.name != interface_name),
+        "disabled test interface unexpectedly appeared in initial snapshot"
+    );
+
+    test_interface.enable();
+    let added = wait_for_matching_update(&receiver, "test interface to be added", |update| {
+        update
+            .diff
+            .added
+            .values()
+            .any(|interface| interface.name == interface_name)
+    });
+    let added_interface = added
+        .diff
+        .added
+        .values()
+        .find(|interface| interface.name == interface_name)
+        .expect("matching added interface should exist");
+    assert!(
+        added_interface.ips.is_empty(),
+        "test interface unexpectedly acquired an address: {:?}",
+        added_interface.ips
+    );
+    let interface_index = added_interface.index;
+    let blocking_added = blocking_receiver
+        .recv_timeout(Duration::from_secs(10))
+        .expect("timeout waiting for blocking test interface addition");
+    assert!(
+        blocking_added.diff.added[&interface_index].ips.is_empty(),
+        "blocking test interface unexpectedly acquired an address: {:?}",
+        blocking_added.diff.added[&interface_index].ips
+    );
+
+    test_interface.disable();
+    let removed = wait_for_matching_update(&receiver, "test interface to be removed", |update| {
+        update.diff.removed.contains_key(&interface_index)
+    });
+    assert_eq!(removed.diff.removed[&interface_index].name, interface_name);
+    let blocking_removed = blocking_receiver
+        .recv_timeout(Duration::from_secs(10))
+        .expect("timeout waiting for blocking test interface removal");
+    assert_eq!(
+        blocking_removed.diff.removed[&interface_index].name,
+        interface_name
+    );
+
+    drop(handle);
+    blocking_thread
+        .join()
+        .expect("blocking watcher thread should not panic");
 }
 
 #[test]

--- a/tests/helpers/windows_interface.rs
+++ b/tests/helpers/windows_interface.rs
@@ -1,0 +1,177 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub struct TestInterface {
+    devcon: PathBuf,
+    device_instance_id: String,
+    name: String,
+}
+
+impl TestInterface {
+    pub fn install_disabled() -> Self {
+        let devcon = find_devcon();
+        let existing = km_test_loopback_adapters()
+            .into_iter()
+            .map(|adapter| adapter.device_instance_id)
+            .collect::<HashSet<_>>();
+        let windows_dir =
+            std::env::var_os("WINDIR").expect("WINDIR should be set on Windows runners");
+        let netloop_inf = PathBuf::from(windows_dir).join("INF").join("netloop.inf");
+
+        run_command(
+            Command::new(&devcon).args([
+                "install".as_ref(),
+                netloop_inf.as_os_str(),
+                "*MSLOOP".as_ref(),
+            ]),
+            "install Microsoft KM-TEST Loopback Adapter",
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let adapter = loop {
+            if let Some(adapter) = km_test_loopback_adapters()
+                .into_iter()
+                .find(|adapter| !existing.contains(&adapter.device_instance_id))
+            {
+                break adapter;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out discovering newly installed Microsoft KM-TEST Loopback Adapter"
+            );
+            thread::sleep(Duration::from_millis(100));
+        };
+
+        let name = format!("netwatcher-test-{}", std::process::id());
+        let test_interface = Self {
+            devcon,
+            device_instance_id: adapter.device_instance_id,
+            name,
+        };
+        test_interface.configure_disabled(adapter.interface_index);
+        test_interface
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn enable(&self) {
+        run_powershell(&format!(
+            "Enable-NetAdapter -Name '{}' -Confirm:$false -ErrorAction Stop",
+            self.name
+        ));
+    }
+
+    pub fn disable(&self) {
+        run_powershell(&format!(
+            "Disable-NetAdapter -Name '{}' -Confirm:$false -ErrorAction Stop",
+            self.name
+        ));
+    }
+
+    fn configure_disabled(&self, interface_index: u32) {
+        run_powershell(&format!(
+            "\
+$adapter = Get-NetAdapter -InterfaceIndex {interface_index} -IncludeHidden -ErrorAction Stop
+$adapter | Rename-NetAdapter -NewName '{}' -Confirm:$false -ErrorAction Stop
+Disable-NetAdapterBinding -Name '{}' -ComponentID ms_tcpip6 -Confirm:$false -ErrorAction Stop
+Set-NetIPInterface -InterfaceAlias '{}' -AddressFamily IPv4 -Dhcp Disabled -ErrorAction Stop
+Get-NetIPAddress -InterfaceAlias '{}' -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+    Remove-NetIPAddress -Confirm:$false -ErrorAction Stop
+Disable-NetAdapter -Name '{}' -Confirm:$false -ErrorAction Stop
+",
+            self.name, self.name, self.name, self.name, self.name
+        ));
+    }
+}
+
+impl Drop for TestInterface {
+    fn drop(&mut self) {
+        let _ = Command::new(&self.devcon)
+            .args(["remove", &format!("@{}", self.device_instance_id)])
+            .output();
+    }
+}
+
+struct AdapterInfo {
+    device_instance_id: String,
+    interface_index: u32,
+}
+
+fn find_devcon() -> PathBuf {
+    let output = run_powershell(
+        "\
+$devcon = Get-Command devcon.exe, devcon64.exe -ErrorAction SilentlyContinue |
+    Select-Object -First 1 -ExpandProperty Source
+$chocolateyPackage = Join-Path $env:ChocolateyInstall 'lib\\devcon.portable'
+if (-not $devcon) {
+    $devcon = Get-ChildItem $chocolateyPackage -Filter devcon64.exe -Recurse -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+$tools = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\\10\\Tools'
+if (-not $devcon) {
+    $devcon = Get-ChildItem $tools -Filter devcon.exe -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match '\\\\x64\\\\devcon\\.exe$' } |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $devcon) {
+    throw 'Could not find DevCon on PATH, in its Chocolatey package, or below Windows Kits'
+}
+$devcon
+",
+    );
+    PathBuf::from(output.trim())
+}
+
+fn km_test_loopback_adapters() -> Vec<AdapterInfo> {
+    let output = run_powershell(
+        "\
+Get-NetAdapter -IncludeHidden |
+    Where-Object { $_.DriverDescription -eq 'Microsoft KM-TEST Loopback Adapter' } |
+    ForEach-Object { \"$($_.PnPDeviceID)|$($_.ifIndex)\" }
+",
+    );
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let (device_instance_id, interface_index) = line
+                .trim()
+                .split_once('|')
+                .expect("unexpected Get-NetAdapter output for KM-TEST adapter");
+            AdapterInfo {
+                device_instance_id: device_instance_id.to_owned(),
+                interface_index: interface_index
+                    .parse()
+                    .expect("KM-TEST adapter should have a numeric interface index"),
+            }
+        })
+        .collect()
+}
+
+fn run_powershell(script: &str) -> String {
+    run_command(
+        Command::new("powershell").args(["-NoProfile", "-Command", script]),
+        "execute PowerShell",
+    )
+}
+
+fn run_command(command: &mut Command, description: &str) -> String {
+    let output = command
+        .output()
+        .unwrap_or_else(|err| panic!("failed to {description}: {err}"));
+    assert!(
+        output.status.success(),
+        "failed to {description} (status {}):\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .unwrap_or_else(|err| panic!("{description} produced non-UTF-8 output: {err}"))
+}


### PR DESCRIPTION
Closes #14.

Adds a Windows-only integration test that installs a disposable Microsoft KM-TEST Loopback Adapter and verifies that both callback and queued/blocking watchers report the address-free interface being added and removed as it is enabled and disabled.

The Windows backend now subscribes to both unicast address changes and IP interface changes. Both notification paths refresh through the existing snapshot and diff machinery, which deduplicates overlapping notifications.