### PR TITLE
Treat interface addresses as unordered when diffing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub use error::Error;
 pub use android::set_android_context;
 
 /// An IP address paired with its prefix length (network mask).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct IpRecord {
     pub ip: IpAddr,
     pub prefix_len: u8,
@@ -183,6 +183,19 @@ impl Interface {
             IpAddr::V4(_) => None,
             IpAddr::V6(ref v6) => Some(v6),
         })
+    }
+
+    /// Canonicalise the address list so that vector equality is equivalent to
+    /// set equality.
+    ///
+    /// Addresses are sorted and duplicates are removed. This makes `Interface`
+    /// (and `List`) equality insensitive to the order in which a platform
+    /// returns addresses, so that a reordering of otherwise identical addresses
+    /// does not produce a spurious "modified" update. It also collapses
+    /// duplicate records into a single canonical entry.
+    fn normalise(&mut self) {
+        self.ips.sort();
+        self.ips.dedup();
     }
 }
 
@@ -486,12 +499,14 @@ mod tests {
         hw_addr: &str,
         ips: impl IntoIterator<Item = IpRecord>,
     ) -> Interface {
-        Interface {
+        let mut interface = Interface {
             index,
             name: name.into(),
             hw_addr: hw_addr.into(),
             ips: ips.into_iter().collect(),
-        }
+        };
+        interface.normalise();
+        interface
     }
 
     fn list(interfaces: impl IntoIterator<Item = Interface>) -> List {
@@ -611,5 +626,90 @@ mod tests {
         assert_eq!(update.diff, UpdateDiff::default());
         assert_eq!(update.addrs_added().next(), None);
         assert_eq!(update.addrs_removed().next(), None);
+    }
+
+    #[test]
+    fn reordered_addresses_do_not_produce_an_update() {
+        let previous = list([interface(1, "iface", "00:00:00:00:00:01", [ip(2), ip(1)])]);
+        let current = list([interface(1, "iface", "00:00:00:00:00:01", [ip(1), ip(2)])]);
+
+        let update = current.update_from(&previous);
+
+        assert!(update.diff.added.is_empty());
+        assert!(update.diff.removed.is_empty());
+        assert!(update.diff.modified.is_empty());
+        assert_eq!(update.addrs_added().next(), None);
+        assert_eq!(update.addrs_removed().next(), None);
+    }
+
+    #[test]
+    fn duplicate_addresses_are_normalised_and_produce_no_update() {
+        let previous = list([interface(
+            1,
+            "iface",
+            "00:00:00:00:00:01",
+            [ip(1), ip(1), ip(2)],
+        )]);
+        let current = list([interface(1, "iface", "00:00:00:00:00:01", [ip(2), ip(1)])]);
+
+        let update = current.update_from(&previous);
+
+        assert!(update.diff.modified.is_empty());
+        assert_eq!(update.interfaces[&1].ips, vec![ip(1), ip(2)]);
+        assert_eq!(update.addrs_added().next(), None);
+        assert_eq!(update.addrs_removed().next(), None);
+    }
+
+    #[test]
+    fn reordering_alongside_real_changes_still_reports_them() {
+        let previous = list([interface(
+            1,
+            "iface",
+            "00:00:00:00:00:01",
+            [ip(1), ip(2), ip(3)],
+        )]);
+        let current = list([interface(
+            1,
+            "iface",
+            "00:00:00:00:00:01",
+            [ip(3), ip(1), ip(4)],
+        )]);
+
+        let update = current.update_from(&previous);
+
+        assert_eq!(
+            update.diff.modified,
+            HashMap::from([(
+                1,
+                InterfaceDiff {
+                    name_changed: false,
+                    hw_addr_changed: false,
+                    addrs_added: vec![ip(4)],
+                    addrs_removed: vec![ip(2)],
+                }
+            )])
+        );
+        assert_eq!(
+            owned_addresses(update.addrs_added()),
+            HashSet::from([(1, ip(4))])
+        );
+        assert_eq!(
+            owned_addresses(update.addrs_removed()),
+            HashSet::from([(1, ip(2))])
+        );
+    }
+
+    #[test]
+    fn normalise_sorts_and_dedups_ips() {
+        let mut iface = Interface {
+            index: 1,
+            name: "iface".into(),
+            hw_addr: "00:00:00:00:00:01".into(),
+            ips: vec![ip(3), ip(1), ip(3), ip(2), ip(1)],
+        };
+
+        iface.normalise();
+
+        assert_eq!(iface.ips, vec![ip(1), ip(2), ip(3)]);
     }
 }

--- a/src/list_unix.rs
+++ b/src/list_unix.rs
@@ -97,15 +97,14 @@ pub(crate) fn list_interfaces() -> Result<List, Error> {
                 .collect();
             // MAC suppressed on Android
             let hw_addr = c.hw_addr.unwrap_or_else(|| "00:00:00:00:00:00".to_string());
-            (
-                c.index,
-                Interface {
-                    index: c.index,
-                    hw_addr,
-                    name: c.name,
-                    ips,
-                },
-            )
+            let mut interface = Interface {
+                index: c.index,
+                hw_addr,
+                name: c.name,
+                ips,
+            };
+            interface.normalise();
+            (c.index, interface)
         })
         .collect();
     Ok(List(ifs))

--- a/src/list_win.rs
+++ b/src/list_win.rs
@@ -103,12 +103,13 @@ pub(crate) fn list_interfaces() -> Result<List, Error> {
                 .FriendlyName
                 .to_string()
                 .unwrap_or_else(|_| "".to_owned());
-            let iface = Interface {
+            let mut iface = Interface {
                 index: ifindex,
                 name,
                 hw_addr,
                 ips,
             };
+            iface.normalise();
             ifs.insert(ifindex, iface);
             adapter_ptr = adapter.Next;
         }


### PR DESCRIPTION
Closes #17

## Problem

`Interface` equality compares `ips: Vec<IpRecord>` in order, but address additions and removals are calculated as sets. If a platform returns the same addresses in a different order, `prev_interface != interface` causes a `modified` entry while `name_changed`, `hw_addr_changed`, `addrs_added`, and `addrs_removed` are all empty. Consumers receive an update that describes no semantic change. Duplicate records can create a similar mismatch.

## Fix

Normalise each interface's address list (sort + dedup) when building a snapshot, so that vector equality becomes equivalent to set equality. This fixes all three order-sensitive checks at once: `Interface` equality, `List` equality in the update cursor's early-exit, and the `ips` vector comparison in the diff calculation.

Applied at construction in `list_unix.rs` (which covers Android) and `list_win.rs`.

## Acceptance criteria

- Reordering otherwise identical addresses emits no update.
- Duplicate normalisation behaviour is defined and tested.
- Real additions and removals still populate `InterfaceDiff`.
- Unit tests added for reordered and duplicate address vectors.

## Tests

4 new unit tests in `src/lib.rs`; `cargo test --lib` and `cargo clippy --all-targets -- -D warnings` pass.