### PR TITLE
Run and fix doc tests in CI

### DIFF
--- a/.github/scripts/rust-ci.sh
+++ b/.github/scripts/rust-ci.sh
@@ -5,6 +5,9 @@ cargo test --lib -- --nocapture
 cargo test --test api_test -- --include-ignored --nocapture
 cargo test --features tokio --test async_api_test -- --include-ignored --nocapture
 cargo test --features async-io --test async_api_test -- --include-ignored --nocapture
+cargo test --doc
+cargo test --features tokio --doc
+cargo test --features async-io --doc
 cargo clippy --all-targets -- -D warnings
 cargo clippy --all-targets --features tokio -- -D warnings
 cargo clippy --all-targets --features async-io -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@
 //! to use the provided adapter.
 //!
 //! ```no_run
+//! # #[cfg(feature = "tokio")]
+//! # {
 //! use netwatcher::async_adapter::Tokio;
 //!
 //! let runtime = tokio::runtime::Builder::new_current_thread()
@@ -105,6 +107,7 @@
 //!         println!("Current interface map: {:#?}", update.interfaces);
 //!     }
 //! });
+//! # }
 //! ```
 
 use std::{


### PR DESCRIPTION
The async-watch doc example uses the tokio-gated Tokio adapter, so it failed to compile under the default (feature-less) doctest run. Gate the example body with a hidden `#[cfg(feature = "tokio")]` so it compiles correctly both with and without the feature, and add `cargo test --doc` runs (default, `tokio`, `async-io`) to the CI script so doctests are actually exercised.