### PR TITLE
Guarantee alignment of the Windows adapter buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "android-build"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "errno"
@@ -263,6 +292,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 name = "netwatcher"
 version = "0.8.0"
 dependencies = [
+ "aligned-vec",
  "android-build",
  "async-io",
  "jni",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ async-io = { version = "2", optional = true }
 ndk-context = "0.1.1"
 jni = "0.22.1"
 
-[target.'cfg(windows)'.dependencies.windows]
-version = "0.62.2"
-features = [
+[target.'cfg(windows)'.dependencies]
+aligned-vec = "0.6"
+windows = { version = "0.62.2", features = [
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
-]
+] }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.build-dependencies]
 android-build = "0.1.4"

--- a/src/list_win.rs
+++ b/src/list_win.rs
@@ -17,17 +17,25 @@ use windows::Win32::Networking::WinSock::{
 };
 
 use crate::{Error, Interface, IpRecord, List};
+use aligned_vec::{AVec, ConstAlign};
 
 pub(crate) fn list_interfaces() -> Result<List, Error> {
     let mut ifs = HashMap::new();
     // Microsoft recommends a 15 KB initial buffer
     let start_size = 15 * 1024;
-    let mut buf: Vec<u8> = vec![0; start_size];
+    // GetAdaptersAddresses fills this buffer with IP_ADAPTER_ADDRESSES_LH structs, so it must
+    // meet that type's alignment. Unlike Vec<u8>, AVec guarantees the requested alignment
+    // regardless of the global allocator.
+    let mut buf: AVec<u8, ConstAlign<8>> = AVec::new(8);
+    buf.resize(start_size, 0);
     let mut sizepointer: u32 = start_size as u32;
 
     unsafe {
         loop {
-            let bufptr = &mut buf[0] as *mut _ as *mut IP_ADAPTER_ADDRESSES_LH;
+            debug_assert!(
+                (buf.as_ptr() as usize).is_multiple_of(align_of::<IP_ADAPTER_ADDRESSES_LH>())
+            );
+            let bufptr = buf.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH;
             let res = GetAdaptersAddresses(
                 AF_UNSPEC.0.into(),
                 GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST,
@@ -50,7 +58,7 @@ pub(crate) fn list_interfaces() -> Result<List, Error> {
         }
 
         // We have at least one
-        let mut adapter_ptr = &buf[0] as *const _ as *const IP_ADAPTER_ADDRESSES_LH;
+        let mut adapter_ptr = buf.as_ptr() as *const IP_ADAPTER_ADDRESSES_LH;
         while !adapter_ptr.is_null() {
             let adapter = &*adapter_ptr as &IP_ADAPTER_ADDRESSES_LH;
             if adapter.OperStatus == IfOperStatusDown {
@@ -116,4 +124,22 @@ pub(crate) fn list_interfaces() -> Result<List, Error> {
     }
 
     Ok(List(ifs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The buffer handed to GetAdaptersAddresses is reinterpreted as IP_ADAPTER_ADDRESSES_LH,
+    // so its alignment must survive both the initial allocation and the growth that follows
+    // ERROR_BUFFER_OVERFLOW. An odd size models the byte counts the API actually reports.
+    #[test]
+    fn adapter_buffer_stays_aligned_across_growth() {
+        let mut buf: AVec<u8, ConstAlign<8>> = AVec::new(8);
+        buf.resize(15 * 1024, 0);
+        assert!((buf.as_ptr() as usize).is_multiple_of(align_of::<IP_ADAPTER_ADDRESSES_LH>()));
+
+        buf.resize(16 * 1024 + 383, 0);
+        assert!((buf.as_ptr() as usize).is_multiple_of(align_of::<IP_ADAPTER_ADDRESSES_LH>()));
+    }
 }


### PR DESCRIPTION
Closes #19

`GetAdaptersAddresses` fills a byte buffer with `IP_ADAPTER_ADDRESSES_LH` structs, but `Vec<u8>` only requests 1-byte alignment. Casting and dereferencing the pointer was therefore UB from a safe public call whenever a custom global allocator returned under-aligned memory (the system allocator happens to be aligned, but Rust doesn't guarantee it).

## Change
- `src/list_win.rs`: replace `Vec<u8>` with `aligned_vec::AVec<u8, ConstAlign<8>>`, which requests the alignment from the allocator and preserves it across the `ERROR_BUFFER_OVERFLOW` growth path.
- Add a `debug_assert!` at the call site (covers initial allocation and every growth) and a Windows-only unit test asserting the alignment invariant across growth to an odd size.
- `Cargo.toml`: `aligned-vec` added as a Windows-only dependency (the only place it's used).

## Verification
- `cargo check --target x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` pass locally.
- mac `cargo test` + doc tests pass (Windows code not exercised on mac).
- Audited aligned-vec 0.6.4 source: realloc uses the stored alignment and matching layouts.